### PR TITLE
Fix table numbering for SAM format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,18 @@ In der ersten Zeile - Header-Zeilen sind am führenden @ zu erkennen - wird mitt
 Die Spalten sind wie folgt definiert:
 
 | Nummer | Name                        | Beschreibung                                                                         |
-|---|-----------------------------|--------------------------------------------------------------------------------------|
-| 1 | Readname                    | Name des Reads                                                                       |
-| 2 | Flag                        | Binärer Flag, beschreibt Zustand des Reads. 0 = gemappt, 4 = nicht gemappt           |
-| 3 | Referenzname                | Name der Referenzsequenz                                                             |
-| 3 | Position                    | Startposition des Mappings (wo der Read der Referenz zugeordnet ist), 1-based        |
-| 4 | Qualität                    | Mapping-Qualität, oder * falls keine Mapping-Qualität berechnet wird                 |
-| 5 | CIGAR                       | CIGAR-String. Format: Siehe Dokumentation (am einfachsten: <Länge des Reads>M)       |
-| 6 | Nächster Read               | Nächster gemappter Read aus dem Read-Paar. Nur relevant für paired end, sonst *      |
-| 7 | Position des nächsten Reads | Position des nächsten gemappten Reads. Nur relevant für paired end, sonst 0          |
-| 8 | Template length             | Geschätzte Länge des Templates. Nur relevant für paired end, sonst 0                 |
-| 9 | Sequenz                     | Read-Sequenz                                                                         |
-| 10 | Basenweise Qualität         | Basenweise Qualität des Mappings, oder * falls Mapping-Qualität nicht berechnet wird |
+|--------|-----------------------------|--------------------------------------------------------------------------------------|
+| 1      | Readname                    | Name des Reads                                                                       |
+| 2      | Flag                        | Binärer Flag, beschreibt Zustand des Reads. 0 = gemappt, 4 = nicht gemappt           |
+| 3      | Referenzname                | Name der Referenzsequenz                                                             |
+| 4      | Position                    | Startposition des Mappings (wo der Read der Referenz zugeordnet ist), 1-based        |
+| 5      | Qualität                    | Mapping-Qualität, oder * falls keine Mapping-Qualität berechnet wird                 |
+| 6      | CIGAR                       | CIGAR-String. Format: Siehe Dokumentation (am einfachsten: <Länge des Reads>M)       |
+| 7      | Nächster Read               | Nächster gemappter Read aus dem Read-Paar. Nur relevant für paired end, sonst *      |
+| 8      | Position des nächsten Reads | Position des nächsten gemappten Reads. Nur relevant für paired end, sonst 0          |
+| 9      | Template length             | Geschätzte Länge des Templates. Nur relevant für paired end, sonst 0                 |
+| 10     | Sequenz                     | Read-Sequenz                                                                         |
+| 11     | Basenweise Qualität         | Basenweise Qualität des Mappings, oder * falls Mapping-Qualität nicht berechnet wird |
 
 Die vollständige Dokumentation des SAM-Formats finden Sie auf der [github-Seite von samtools](https://samtools.github.io/hts-specs/SAMv1.pdf). 
 

--- a/README_en.md
+++ b/README_en.md
@@ -34,14 +34,14 @@ The fields in the following non-header lines are defined as follows:
 | 1      | Readname                  | Name of the Read                                                                                             |
 | 2      | Flag                      | Bnary flag that describes the state of the read. 0=mapped, 4=not mapped                                      |
 | 3      | Reference name            | Name of the reference sequence the read was mapped to (must be same as the one given by "SN:" in the header) |
-| 3      | Position                  | Start position of the read (i.e. where the read was assigned to the reference), 1-based                      |
-| 4      | Quality                   | Mapping quality, or * if no mapping quality was computed by the mapper                                       |
-| 5      | CIGAR                     | CIGAR-String. Format: See documentation (in our case simply: <length of the read>M)                          |
-| 6      | Next read                 | Next mapped read from the read pair. Only for paired reads, otherwise *                                      |
-| 7      | Position of the next read | Position of the next mapped read from the read pair. Only for paired reads, otherwise 0                      |
-| 8      | Template length           | Estimated length of the template. Only for paired reads, otherwise 0                                         |
-| 9      | Sequence                  | Read sequence                                                                                                |
-| 10     | Basewise quality | Basewise quality of the mapping, or * if the mapper does not compute a mapping quality                       |
+| 4      | Position                  | Start position of the read (i.e. where the read was assigned to the reference), 1-based                      |
+| 5      | Quality                   | Mapping quality, or * if no mapping quality was computed by the mapper                                       |
+| 6      | CIGAR                     | CIGAR-String. Format: See documentation (in our case simply: <length of the read>M)                          |
+| 7      | Next read                 | Next mapped read from the read pair. Only for paired reads, otherwise *                                      |
+| 8      | Position of the next read | Position of the next mapped read from the read pair. Only for paired reads, otherwise 0                      |
+| 9      | Template length           | Estimated length of the template. Only for paired reads, otherwise 0                                         |
+| 10     | Sequence                  | Read sequence                                                                                                |
+| 11     | Basewise quality          | Basewise quality of the mapping, or * if the mapper does not compute a mapping quality                       |
 
 The complete documentation of the format can be found on the [github page of samtools](https://samtools.github.io/hts-specs/SAMv1.pdf). 
 


### PR DESCRIPTION
I was a bit confused by the way the table was indexed. At first i thought the duplicated 3 means that the two columns actually belongs together. SAM spec proofed me wrong.

I fixed it to match the SAM spec to prevent others from being confused.